### PR TITLE
device-config: add configuration for Onyx+

### DIFF
--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
@@ -1454,6 +1454,23 @@
             },
             "FleshlightLaunchFW12Cmd": {}
           }
+        },
+        {
+          "identifier": [
+            "Onyx+"
+          ],
+          "name": {
+            "en-us": "Kiiroo Onyx +"
+          },
+          "messages": {
+            "LinearCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            },
+            "FleshlightLaunchFW12Cmd": {}
+          }
         }
       ]
     },

--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -1048,6 +1048,16 @@ protocols:
             StepCount:
               - 99
           FleshlightLaunchFW12Cmd: {}
+      - identifier:
+          - Onyx+
+        name:
+          en-us: Kiiroo Onyx+
+        messages:
+          LinearCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+          FleshlightLaunchFW12Cmd: {}
   erostek-et312:
     serial:
       - port: default


### PR DESCRIPTION
The device configuration has been missing before, so whenever a Onyx+ has been
detected, it has been ignored as the device configuration could not be found.

This should fix #160