### PR TITLE
move motor on kiiroo_v21 initialization

### DIFF
--- a/buttplug/Cargo.toml
+++ b/buttplug/Cargo.toml
@@ -85,7 +85,8 @@ rusty-xinput = "1.2.0"
 version = "1.6.3"
 # default-features = false
 # features = ["std"]
-optional = true
+# optional = true
+features = [ "attributes" ]
 
 [dev-dependencies]
 async-std = "1.6.3"

--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
@@ -1454,6 +1454,23 @@
             },
             "FleshlightLaunchFW12Cmd": {}
           }
+        },
+        {
+          "identifier": [
+            "Onyx+"
+          ],
+          "name": {
+            "en-us": "Kiiroo Onyx +"
+          },
+          "messages": {
+            "LinearCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                99
+              ]
+            },
+            "FleshlightLaunchFW12Cmd": {}
+          }
         }
       ]
     },

--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -1048,6 +1048,16 @@ protocols:
             StepCount:
               - 99
           FleshlightLaunchFW12Cmd: {}
+      - identifier:
+          - Onyx+
+        name:
+          en-us: Kiiroo Onyx+
+        messages:
+          LinearCmd:
+            FeatureCount: 1
+            StepCount:
+              - 99
+          FleshlightLaunchFW12Cmd: {}
   erostek-et312:
     serial:
       - port: default


### PR DESCRIPTION
this seems to be required so that the Onyx+ does not automatically
disconnects after it has been connected after a few seconds.

This relates to #158