### PR TITLE
feat: Add Lovense Mission to config

### DIFF
--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
@@ -53,6 +53,10 @@
           "4c300001-0023-4bd4-bbd5-a6920e4c5653": {
             "tx": "4c300002-0023-4bd4-bbd5-a6920e4c5653",
             "rx": "4c300003-0023-4bd4-bbd5-a6920e4c5653"
+          },
+          "56300001-0023-4bd4-bbd5-a6920e4c5653": {
+            "tx": "56300002-0023-4bd4-bbd5-a6920e4c5653",
+            "rx": "56300003-0023-4bd4-bbd5-a6920e4c5653"
           }
         }
       },
@@ -149,6 +153,14 @@
           ],
           "name": {
             "en-us": "Lovense Osci"
+          }
+        },
+        {
+          "identifier": [
+            "V"
+          ],
+          "name": {
+            "en-us": "Lovense Mission"
           }
         }
       ]
@@ -1464,7 +1476,7 @@
             "Onyx+"
           ],
           "name": {
-            "en-us": "Kiiroo Onyx +"
+            "en-us": "Kiiroo Onyx+"
           },
           "messages": {
             "LinearCmd": {

--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -168,10 +168,13 @@ protocols:
           rx: 42300003-0023-4bd4-bbd5-a6920e4c5653
         43300001-0023-4bd4-bbd5-a6920e4c5653: # New Nora
           tx: 43300002-0023-4bd4-bbd5-a6920e4c5653
-          rx: 43300003-0023-4bd4-bbd5-a6920e4c5653          
+          rx: 43300003-0023-4bd4-bbd5-a6920e4c5653
         4c300001-0023-4bd4-bbd5-a6920e4c5653: # Ambi
           tx: 4c300002-0023-4bd4-bbd5-a6920e4c5653
-          rx: 4c300003-0023-4bd4-bbd5-a6920e4c5653          
+          rx: 4c300003-0023-4bd4-bbd5-a6920e4c5653
+        56300001-0023-4bd4-bbd5-a6920e4c5653: # Mission
+          tx: 56300002-0023-4bd4-bbd5-a6920e4c5653
+          rx: 56300003-0023-4bd4-bbd5-a6920e4c5653
     defaults:
       messages:
         VibrateCmd:
@@ -227,6 +230,10 @@ protocols:
           - O
         name:
           en-us: Lovense Osci
+      - identifier:
+          - V
+        name:
+          en-us: Lovense Mission
   xinput:
     # This will actually be ANY gamepad that supports XInput. XInput
     # is its own connector type, so we don't have any special


### PR DESCRIPTION
Config only change to get support for the mission.

Note that when not set to vibrate, the depth sensor will control the speed.