### PR TITLE
chore: Manually merging 3fb841bc from device-config repo

### DIFF
--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.json
@@ -367,7 +367,8 @@
           "LuWuShuang",
           "LiBo",
           "QingTing",
-          "Huohu"
+          "Huohu",
+          "Yuyi"
         ],
         "services": {
           "00006000-0000-1000-8000-00805f9b34fb": {
@@ -451,6 +452,14 @@
           ],
           "name": {
             "en-us": "Libo Lara"
+          }
+        },
+        {
+          "identifier": [
+            "Yuyi"
+          ],
+          "name": {
+            "en-us": "Libo Feather"
           }
         },
         {
@@ -846,13 +855,11 @@
           "4_Plus",
           "4plus",
           "Bloom",
-          "Chrous",
           "classic",
           "Classic",
           "Ditto",
           "Gala",
           "Jive",
-          "Melt",
           "Nova",
           "NOVAV2",
           "Pivot",
@@ -860,7 +867,6 @@
           "Skeena",
           "Sync",
           "Verge",
-          "Wand",
           "Wish"
         ],
         "services": {
@@ -909,14 +915,6 @@
         },
         {
           "identifier": [
-            "Melt"
-          ],
-          "name": {
-            "en-us": "WeVibe Melt"
-          }
-        },
-        {
-          "identifier": [
             "Pivot"
           ],
           "name": {
@@ -941,26 +939,10 @@
         },
         {
           "identifier": [
-            "Chorus"
-          ],
-          "name": {
-            "en-us": "WeVibe Chorus"
-          }
-        },
-        {
-          "identifier": [
             "Skeena"
           ],
           "name": {
             "en-us": "WeVibe Skeena"
-          }
-        },
-        {
-          "identifier": [
-            "Wand"
-          ],
-          "name": {
-            "en-us": "WeVibe Wand"
           }
         },
         {
@@ -1050,8 +1032,11 @@
     "wevibe-8bit": {
       "btle": {
         "names": [
+          "Chorus",
+          "Melt",
           "Moxie",
-          "Vector"
+          "Vector",
+          "Wand"
         ],
         "services": {
           "f000bb03-0451-4000-b000-000000000000": {
@@ -1075,6 +1060,39 @@
       "configurations": [
         {
           "identifier": [
+            "Chorus"
+          ],
+          "name": {
+            "en-us": "WeVibe Chorus"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 2,
+              "StepCount": [
+                27,
+                27
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Melt"
+          ],
+          "name": {
+            "en-us": "WeVibe Melt"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                22
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
             "Moxie"
           ],
           "name": {
@@ -1094,6 +1112,22 @@
               "StepCount": [
                 12,
                 12
+              ]
+            }
+          }
+        },
+        {
+          "identifier": [
+            "Wand"
+          ],
+          "name": {
+            "en-us": "WeVibe Wand"
+          },
+          "messages": {
+            "VibrateCmd": {
+              "FeatureCount": 1,
+              "StepCount": [
+                22
               ]
             }
           }

--- a/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/dependencies/buttplug-device-config/buttplug-device-config.yml
@@ -382,6 +382,7 @@ protocols:
           - LiBo # Lily - Double ended mini wand
           - QingTing # Lucy - Dragonfly egg
           - Huohu # Lara/Sexy Fox - Rabbit
+          - Yuyi # Feather
         services:
           # Write Service
           00006000-0000-1000-8000-00805f9b34fb:
@@ -428,6 +429,10 @@ protocols:
             - Huohu
           name:
             en-us: Libo Lara
+        - identifier:
+            - Yuyi
+          name:
+            en-us: Libo Feather
         # Suction Vibes
         - identifier:
             - BaiHu
@@ -669,13 +674,11 @@ protocols:
         - 4_Plus # 4 Plus alias
         - 4plus # 4 Plus alias
         - Bloom
-        - Chrous
         - classic # 4 Plus alias
         - Classic # 4 Plus alias
         - Ditto
         - Gala
         - Jive
-        - Melt
         - Nova
         - NOVAV2
         - Pivot
@@ -683,7 +686,6 @@ protocols:
         - Skeena
         - Sync
         - Verge
-        - Wand
         - Wish
       services:
         f000bb03-0451-4000-b000-000000000000:
@@ -712,10 +714,6 @@ protocols:
         name:
           en-us: WeVibe Jive
       - identifier:
-          - Melt
-        name:
-          en-us: WeVibe Melt
-      - identifier:
           - Pivot
         name:
           en-us: WeVibe Pivot
@@ -728,17 +726,9 @@ protocols:
         name:
           en-us: WeVibe Verge
       - identifier:
-          - Chorus
-        name:
-          en-us: WeVibe Chorus
-      - identifier:
           - Skeena
         name:
           en-us: WeVibe Skeena
-      - identifier:
-          - Wand
-        name:
-          en-us: WeVibe Wand
       - identifier:
           - Wish
         name:
@@ -793,8 +783,11 @@ protocols:
   wevibe-8bit:
     btle:
       names:
+        - Chorus
+        - Melt
         - Moxie
         - Vector
+        - Wand
       services:
         f000bb03-0451-4000-b000-000000000000:
           tx: f000c000-0451-4000-b000-000000000000
@@ -809,6 +802,25 @@ protocols:
             - 12
     configurations:
       - identifier:
+          - Chorus
+        name:
+          en-us: WeVibe Chorus
+        messages:
+          VibrateCmd:
+            FeatureCount: 2
+            StepCount:
+              - 27
+              - 27
+      - identifier:
+          - Melt
+        name:
+          en-us: WeVibe Melt
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 22
+      - identifier:
           - Moxie
         name:
           en-us: WeVibe Moxie
@@ -822,6 +834,15 @@ protocols:
             StepCount:
               - 12
               - 12
+      - identifier:
+          - Wand
+        name:
+          en-us: WeVibe Wand
+        messages:
+          VibrateCmd:
+            FeatureCount: 1
+            StepCount:
+              - 22
   wevibe-legacy:
     btle:
       names:


### PR DESCRIPTION
Turns out that buttplug-rs's device config is 5 commits
ahead of the device config repo and 1 behind. It might
be possible to do the subtree merge thing to pull these
in order, but the manual merge was trivial to bring over
the one missing change:

A few WeVibe devices were listed under the wevibe protocol
where they really needed to be listed under wevibe-8bit:
- Chorus
- Melt
- Wand

The Libo Feather also made its way into the config in that
change.