### PR TITLE
ButtplugFutureStateShared: fix send/sync impl

### DIFF
--- a/buttplug/src/util/future.rs
+++ b/buttplug/src/util/future.rs
@@ -85,11 +85,6 @@ pub struct ButtplugFutureStateShared<T> {
   state: Arc<Mutex<ButtplugFutureState<T>>>,
 }
 
-unsafe impl<T: Sync> Sync for ButtplugFutureStateShared<T> {
-}
-unsafe impl<T: Send> Send for ButtplugFutureStateShared<T> {
-}
-
 impl<T> ButtplugFutureStateShared<T> {
   pub fn new(state: ButtplugFutureState<T>) -> Self {
     Self {


### PR DESCRIPTION
Hello :crab:,
I had previously suggested a fix to the `Send/Sync` impl of `ButtplugFutureStateShared` in #225,
and the fix was made in https://github.com/buttplugio/buttplug-rs/commit/3199bd8623d05341b4047f53e143ae67d7d9f064 .

However @Qwaz pointed out in https://github.com/buttplugio/buttplug-rs/issues/225#issuecomment-751514747 that
part of the suggestion I had made was incorrect, and this PR is to make a follow-up fix.

After the fix, the requirement for `ButtplugFutureStateShared<T>` to be `Sync` becomes `T: Send` instead of `T: Sync`.
(via auto trait implementations)

Sorry for the mistake I made in my previous suggestion,
and thank you for reviewing this PR :+1: 
