### PR TITLE
Libo support

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -258,8 +258,8 @@
           "VibrateCmd": {
             "FeatureCount": 2,
             "StepCount": [
-              3,
-              14
+              14,
+              3
             ]
           }
         }

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -311,8 +311,8 @@ protocols:
           VibrateCmd:
             FeatureCount: 2
             StepCount:
-              - 3  # Vibe
               - 14 # Estim
+              - 3  # Vibe
       configurations:
         - identifier:
             - PiPiJing

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -325,7 +325,7 @@ protocols:
   libo-shark:
       btle:
         names:
-          - ShaYu # Shark - Enflating Rabbit
+          - ShaYu # Shark - Inflating Rabbit
         services:
           # Write Service
           00006000-0000-1000-8000-00805f9b34fb:

--- a/buttplug/src/device/protocol/libo_elle.rs
+++ b/buttplug/src/device/protocol/libo_elle.rs
@@ -1,0 +1,169 @@
+use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
+use crate::{
+  core::messages::{self, ButtplugDeviceCommandMessageUnion, MessageAttributesMap},
+  device::{
+    protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
+    DeviceImpl, DeviceWriteCmd, Endpoint,
+  },
+};
+use async_lock::Mutex;
+use std::sync::Arc;
+
+#[derive(ButtplugProtocolProperties)]
+pub struct LiboElle {
+  name: String,
+  message_attributes: MessageAttributesMap,
+  manager: Arc<Mutex<GenericCommandManager>>,
+  stop_commands: Vec<ButtplugDeviceCommandMessageUnion>,
+}
+
+impl ButtplugProtocol for LiboElle {
+  fn new_protocol(
+    name: &str,
+    message_attributes: MessageAttributesMap,
+  ) -> Box<dyn ButtplugProtocol> {
+    let manager = GenericCommandManager::new(&message_attributes);
+
+    Box::new(Self {
+      name: name.to_owned(),
+      message_attributes,
+      stop_commands: manager.get_stop_commands(),
+      manager: Arc::new(Mutex::new(manager)),
+    })
+  }
+}
+
+impl ButtplugProtocolCommandHandler for LiboElle {
+  fn handle_vibrate_cmd(
+    &self,
+    device: Arc<Box<dyn DeviceImpl>>,
+    message: messages::VibrateCmd,
+  ) -> ButtplugDeviceResultFuture {
+    // Store off result before the match, so we drop the lock ASAP.
+    let manager = self.manager.clone();
+    Box::pin(async move {
+      let result = manager.lock().await.update_vibration(&message, false)?;
+      let mut fut_vec = vec![];
+      if let Some(cmds) = result {
+        for (index, cmd) in cmds.iter().enumerate() {
+          if let Some(speed) = cmd {
+            if index == 0 {
+              let mut data = 0u8;
+              if *speed as u8 > 0 && *speed as u8 <= 7 {
+                data |= (*speed as u8 - 1) << 4;
+                data |= 1; // Set the mode too
+              } else if *speed as u8 > 7 {
+                data |= (*speed as u8 - 8) << 4;
+                data |= 4; // Set the mode too
+              }
+              fut_vec.push(device.write_value(DeviceWriteCmd::new(
+                Endpoint::Tx,
+                vec![data],
+                false,
+              )));
+            } else if index == 1 {
+              fut_vec.push(device.write_value(DeviceWriteCmd::new(
+                Endpoint::TxMode,
+                vec![*speed as u8],
+                false,
+              )));
+            }
+          }
+        }
+      }
+      // TODO Just use join_all here
+      for fut in fut_vec {
+        // TODO Do something about possible errors here
+        fut.await?;
+      }
+      Ok(messages::Ok::default().into())
+    })
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use crate::{
+    core::messages::{StopDeviceCmd, VibrateCmd, VibrateSubcommand},
+    device::{DeviceImplCommand, DeviceWriteCmd, Endpoint},
+    test::{check_recv_value, new_bluetoothle_test_device},
+    util::async_manager,
+  };
+
+  #[test]
+  pub fn test_libo_elle_protocol() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("PiPiJing").await.unwrap();
+      let command_receiver_tx = test_device
+        .get_endpoint_channel(&Endpoint::Tx)
+        .unwrap()
+        .receiver;
+      let command_receiver_tx_mode = test_device
+        .get_endpoint_channel(&Endpoint::TxMode)
+        .unwrap()
+        .receiver;
+      device
+        .parse_message(
+          VibrateCmd::new(
+            0,
+            vec![
+              VibrateSubcommand::new(0, 0.5),
+              VibrateSubcommand::new(1, 0.5),
+            ],
+          )
+          .into(),
+        )
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x61], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x02], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(1, 1.0)]).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x03], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+      assert!(command_receiver_tx.is_empty());
+
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      assert!(command_receiver_tx.is_empty());
+      assert!(command_receiver_tx_mode.is_empty());
+
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+    });
+  }
+}

--- a/buttplug/src/device/protocol/libo_shark.rs
+++ b/buttplug/src/device/protocol/libo_shark.rs
@@ -1,0 +1,136 @@
+use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
+use crate::{
+  core::messages::{self, ButtplugDeviceCommandMessageUnion, MessageAttributesMap},
+  device::{
+    protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
+    DeviceImpl, DeviceWriteCmd, Endpoint,
+  },
+};
+use async_lock::Mutex;
+use std::sync::Arc;
+
+#[derive(ButtplugProtocolProperties)]
+pub struct LiboShark {
+  name: String,
+  message_attributes: MessageAttributesMap,
+  manager: Arc<Mutex<GenericCommandManager>>,
+  stop_commands: Vec<ButtplugDeviceCommandMessageUnion>,
+}
+
+impl ButtplugProtocol for LiboShark {
+  fn new_protocol(
+    name: &str,
+    message_attributes: MessageAttributesMap,
+  ) -> Box<dyn ButtplugProtocol> {
+    let manager = GenericCommandManager::new(&message_attributes);
+
+    Box::new(Self {
+      name: name.to_owned(),
+      message_attributes,
+      stop_commands: manager.get_stop_commands(),
+      manager: Arc::new(Mutex::new(manager)),
+    })
+  }
+}
+
+impl ButtplugProtocolCommandHandler for LiboShark {
+  fn handle_vibrate_cmd(
+    &self,
+    device: Arc<Box<dyn DeviceImpl>>,
+    message: messages::VibrateCmd,
+  ) -> ButtplugDeviceResultFuture {
+    // Store off result before the match, so we drop the lock ASAP.
+    let manager = self.manager.clone();
+    Box::pin(async move {
+      let result = manager.lock().await.update_vibration(&message, true)?;
+      if let Some(cmds) = result {
+        let mut data = 0u8;
+        if let Some(speed) = cmds[0] {
+          data |= (speed as u8) << 4;
+        }
+        if let Some(speed) = cmds[1] {
+          data |= speed as u8;
+        }
+        device.write_value(DeviceWriteCmd::new(
+          Endpoint::Tx,
+          vec![data],
+          false,
+        )).await?;
+      }
+      Ok(messages::Ok::default().into())
+    })
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use crate::{
+    core::messages::{StopDeviceCmd, VibrateCmd, VibrateSubcommand},
+    device::{DeviceImplCommand, DeviceWriteCmd, Endpoint},
+    test::{check_recv_value, new_bluetoothle_test_device},
+    util::async_manager,
+  };
+
+  #[test]
+  pub fn test_libo_shark_protocol() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("ShaYu").await.unwrap();
+      let command_receiver_tx = test_device
+        .get_endpoint_channel(&Endpoint::Tx)
+        .unwrap()
+        .receiver;
+      let command_receiver_tx_mode = test_device
+        .get_endpoint_channel(&Endpoint::TxMode)
+        .unwrap()
+        .receiver;
+      device
+        .parse_message(
+          VibrateCmd::new(
+            0,
+            vec![
+              VibrateSubcommand::new(0, 0.5),
+              VibrateSubcommand::new(1, 0.5),
+            ],
+          )
+          .into(),
+        )
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x22], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(1, 1.0)]).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x23], false)),
+      )
+          .await;
+      assert!(command_receiver_tx.is_empty());
+
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      assert!(command_receiver_tx.is_empty());
+
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      assert!(command_receiver_tx_mode.is_empty());
+    });
+  }
+}

--- a/buttplug/src/device/protocol/libo_vibes.rs
+++ b/buttplug/src/device/protocol/libo_vibes.rs
@@ -1,0 +1,220 @@
+use super::{ButtplugDeviceResultFuture, ButtplugProtocol, ButtplugProtocolCommandHandler};
+use crate::{
+  core::messages::{self, ButtplugDeviceCommandMessageUnion, MessageAttributesMap},
+  device::{
+    protocol::{generic_command_manager::GenericCommandManager, ButtplugProtocolProperties},
+    DeviceImpl, DeviceWriteCmd, Endpoint,
+  },
+};
+use async_lock::Mutex;
+use std::sync::Arc;
+
+#[derive(ButtplugProtocolProperties)]
+pub struct LiboVibes {
+  name: String,
+  message_attributes: MessageAttributesMap,
+  manager: Arc<Mutex<GenericCommandManager>>,
+  stop_commands: Vec<ButtplugDeviceCommandMessageUnion>,
+}
+
+impl ButtplugProtocol for LiboVibes {
+  fn new_protocol(
+    name: &str,
+    message_attributes: MessageAttributesMap,
+  ) -> Box<dyn ButtplugProtocol> {
+    let manager = GenericCommandManager::new(&message_attributes);
+
+    Box::new(Self {
+      name: name.to_owned(),
+      message_attributes,
+      stop_commands: manager.get_stop_commands(),
+      manager: Arc::new(Mutex::new(manager)),
+    })
+  }
+}
+
+impl ButtplugProtocolCommandHandler for LiboVibes {
+  fn handle_vibrate_cmd(
+    &self,
+    device: Arc<Box<dyn DeviceImpl>>,
+    message: messages::VibrateCmd,
+  ) -> ButtplugDeviceResultFuture {
+    // Store off result before the match, so we drop the lock ASAP.
+    let manager = self.manager.clone();
+    Box::pin(async move {
+      let result = manager.lock().await.update_vibration(&message, false)?;
+      let mut fut_vec = vec![];
+      if let Some(cmds) = result {
+        for (index, cmd) in cmds.iter().enumerate() {
+          if let Some(speed) = cmd {
+            if index == 0 {
+              fut_vec.push(device.write_value(DeviceWriteCmd::new(
+                Endpoint::Tx,
+                vec![*speed as u8],
+                false,
+              )));
+
+              // If this is a single vibe device, we need to send stop to TxMode too
+              if *speed as u8 == 0 && cmds.len() == 1 {
+                fut_vec.push(device.write_value(DeviceWriteCmd::new(
+                  Endpoint::TxMode,
+                  vec![0u8],
+                  false,
+                )));
+              }
+            } else if index == 1 {
+              fut_vec.push(device.write_value(DeviceWriteCmd::new(
+                Endpoint::TxMode,
+                vec![*speed as u8],
+                false,
+              )));
+            }
+          }
+        }
+      }
+      // TODO Just use join_all here
+      for fut in fut_vec {
+        // TODO Do something about possible errors here
+        fut.await?;
+      }
+      Ok(messages::Ok::default().into())
+    })
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use crate::{
+    core::messages::{StopDeviceCmd, VibrateCmd, VibrateSubcommand},
+    device::{DeviceImplCommand, DeviceWriteCmd, Endpoint},
+    test::{check_recv_value, new_bluetoothle_test_device},
+    util::async_manager,
+  };
+
+  #[test]
+  pub fn test_libo_vibes_protocol_1vibe() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("Yuyi").await.unwrap();
+      let command_receiver_tx = test_device
+        .get_endpoint_channel(&Endpoint::Tx)
+        .unwrap()
+        .receiver;
+      let command_receiver_tx_mode = test_device
+        .get_endpoint_channel(&Endpoint::TxMode)
+        .unwrap()
+        .receiver;
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x32], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      assert!(command_receiver_tx_mode.is_empty());
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      assert!(command_receiver_tx.is_empty());
+      assert!(command_receiver_tx_mode.is_empty());
+
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+    });
+  }
+  #[test]
+  pub fn test_libo_vibes_protocol_2vibe() {
+    async_manager::block_on(async move {
+      let (device, test_device) = new_bluetoothle_test_device("Gugudai").await.unwrap();
+      let command_receiver_tx = test_device
+        .get_endpoint_channel(&Endpoint::Tx)
+        .unwrap()
+        .receiver;
+      let command_receiver_tx_mode = test_device
+        .get_endpoint_channel(&Endpoint::TxMode)
+        .unwrap()
+        .receiver;
+      device
+        .parse_message(
+          VibrateCmd::new(
+            0,
+            vec![
+              VibrateSubcommand::new(0, 0.5),
+              VibrateSubcommand::new(1, 0.5),
+            ],
+          )
+          .into(),
+        )
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x32], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x02], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+
+      // Since we only created one subcommand, we should only receive one command.
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(1, 1.0)]).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x03], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+      assert!(command_receiver_tx.is_empty());
+
+      device
+        .parse_message(VibrateCmd::new(0, vec![VibrateSubcommand::new(0, 0.5)]).into())
+        .await
+        .unwrap();
+      assert!(command_receiver_tx.is_empty());
+      assert!(command_receiver_tx_mode.is_empty());
+
+      device
+        .parse_message(StopDeviceCmd::new(0).into())
+        .await
+        .unwrap();
+      check_recv_value(
+        &command_receiver_tx,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::Tx, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx.is_empty());
+      check_recv_value(
+        &command_receiver_tx_mode,
+        DeviceImplCommand::Write(DeviceWriteCmd::new(Endpoint::TxMode, vec![0x00], false)),
+      )
+      .await;
+      assert!(command_receiver_tx_mode.is_empty());
+    });
+  }
+}

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -6,6 +6,7 @@ mod kiiroo_v21;
 mod kiiroo_v2_vibrator;
 mod lelof1s;
 mod libo_elle;
+mod libo_vibes;
 mod lovehoney_desire;
 mod lovense;
 mod magic_motion_v1;
@@ -52,6 +53,7 @@ pub enum ProtocolTypes {
   KiirooV21,
   LeloF1s,
   LiboElle,
+  LiboVibes,
   LovehoneyDesire,
   Lovense,
   MagicMotionV1,
@@ -85,6 +87,7 @@ impl TryFrom<&str> for ProtocolTypes {
       "kiiroo-v21" => Ok(ProtocolTypes::KiirooV21),
       "lelo-f1s" => Ok(ProtocolTypes::LeloF1s),
       "libo-elle" => Ok(ProtocolTypes::LiboElle),
+      "libo-vibes" => Ok(ProtocolTypes::LiboVibes),
       "lovehoney-desire" => Ok(ProtocolTypes::LovehoneyDesire),
       "lovense" => Ok(ProtocolTypes::Lovense),
       "magic-motion-1" => Ok(ProtocolTypes::MagicMotionV1),
@@ -127,6 +130,7 @@ pub fn try_create_protocol(
     ProtocolTypes::KiirooV21 => kiiroo_v21::KiirooV21::try_create(device, config),
     ProtocolTypes::LeloF1s => lelof1s::LeloF1s::try_create(device, config),
     ProtocolTypes::LiboElle => libo_elle::LiboElle::try_create(device, config),
+    ProtocolTypes::LiboVibes => libo_vibes::LiboVibes::try_create(device, config),
     ProtocolTypes::LovehoneyDesire => lovehoney_desire::LovehoneyDesire::try_create(device, config),
     ProtocolTypes::Lovense => lovense::Lovense::try_create(device, config),
     ProtocolTypes::MagicMotionV1 => magic_motion_v1::MagicMotionV1::try_create(device, config),

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -5,6 +5,7 @@ mod kiiroo_v2;
 mod kiiroo_v21;
 mod kiiroo_v2_vibrator;
 mod lelof1s;
+mod libo_elle;
 mod lovehoney_desire;
 mod lovense;
 mod magic_motion_v1;
@@ -31,20 +32,12 @@ use crate::{
   core::{
     errors::{ButtplugDeviceError, ButtplugError},
     messages::{
-      self,
-      ButtplugDeviceCommandMessageUnion,
-      ButtplugDeviceMessageType,
-      ButtplugMessage,
-      MessageAttributesMap,
-      RawReading,
-      VibrateCmd,
-      VibrateSubcommand,
+      self, ButtplugDeviceCommandMessageUnion, ButtplugDeviceMessageType, ButtplugMessage,
+      MessageAttributesMap, RawReading, VibrateCmd, VibrateSubcommand,
     },
   },
   device::{
-    configuration_manager::DeviceProtocolConfiguration,
-    ButtplugDeviceResultFuture,
-    DeviceReadCmd,
+    configuration_manager::DeviceProtocolConfiguration, ButtplugDeviceResultFuture, DeviceReadCmd,
     Endpoint,
   },
 };
@@ -58,6 +51,7 @@ pub enum ProtocolTypes {
   KiirooV2Vibrator,
   KiirooV21,
   LeloF1s,
+  LiboElle,
   LovehoneyDesire,
   Lovense,
   MagicMotionV1,
@@ -90,6 +84,7 @@ impl TryFrom<&str> for ProtocolTypes {
       "kiiroo-v2-vibrator" => Ok(ProtocolTypes::KiirooV2Vibrator),
       "kiiroo-v21" => Ok(ProtocolTypes::KiirooV21),
       "lelo-f1s" => Ok(ProtocolTypes::LeloF1s),
+      "libo-elle" => Ok(ProtocolTypes::LiboElle),
       "lovehoney-desire" => Ok(ProtocolTypes::LovehoneyDesire),
       "lovense" => Ok(ProtocolTypes::Lovense),
       "magic-motion-1" => Ok(ProtocolTypes::MagicMotionV1),
@@ -131,6 +126,7 @@ pub fn try_create_protocol(
     }
     ProtocolTypes::KiirooV21 => kiiroo_v21::KiirooV21::try_create(device, config),
     ProtocolTypes::LeloF1s => lelof1s::LeloF1s::try_create(device, config),
+    ProtocolTypes::LiboElle => libo_elle::LiboElle::try_create(device, config),
     ProtocolTypes::LovehoneyDesire => lovehoney_desire::LovehoneyDesire::try_create(device, config),
     ProtocolTypes::Lovense => lovense::Lovense::try_create(device, config),
     ProtocolTypes::MagicMotionV1 => magic_motion_v1::MagicMotionV1::try_create(device, config),

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -6,6 +6,7 @@ mod kiiroo_v21;
 mod kiiroo_v2_vibrator;
 mod lelof1s;
 mod libo_elle;
+mod libo_shark;
 mod libo_vibes;
 mod lovehoney_desire;
 mod lovense;
@@ -53,6 +54,7 @@ pub enum ProtocolTypes {
   KiirooV21,
   LeloF1s,
   LiboElle,
+  LiboShark,
   LiboVibes,
   LovehoneyDesire,
   Lovense,
@@ -87,6 +89,7 @@ impl TryFrom<&str> for ProtocolTypes {
       "kiiroo-v21" => Ok(ProtocolTypes::KiirooV21),
       "lelo-f1s" => Ok(ProtocolTypes::LeloF1s),
       "libo-elle" => Ok(ProtocolTypes::LiboElle),
+      "libo-shark" => Ok(ProtocolTypes::LiboShark),
       "libo-vibes" => Ok(ProtocolTypes::LiboVibes),
       "lovehoney-desire" => Ok(ProtocolTypes::LovehoneyDesire),
       "lovense" => Ok(ProtocolTypes::Lovense),
@@ -130,6 +133,7 @@ pub fn try_create_protocol(
     ProtocolTypes::KiirooV21 => kiiroo_v21::KiirooV21::try_create(device, config),
     ProtocolTypes::LeloF1s => lelof1s::LeloF1s::try_create(device, config),
     ProtocolTypes::LiboElle => libo_elle::LiboElle::try_create(device, config),
+    ProtocolTypes::LiboShark => libo_shark::LiboShark::try_create(device, config),
     ProtocolTypes::LiboVibes => libo_vibes::LiboVibes::try_create(device, config),
     ProtocolTypes::LovehoneyDesire => lovehoney_desire::LovehoneyDesire::try_create(device, config),
     ProtocolTypes::Lovense => lovense::Lovense::try_create(device, config),


### PR DESCRIPTION
This PR includes each of the 3 Libo Protocols (1 commit each).
Tests passed locally and with all applicable devices.

The LiboShark protocol skips the futures array, since it only one characteristic, the other 2 protocols follow the pattern used in other multi-characteristic protocols.

~~The LiboVibes protocol needs to know the number of vibrators, which I'm fetching from the message_attributes, but I suspect there's a better way to get that value (I'll update that logic pending feedback).~~ Answered my own question: `cmds.len()` is the vibration count.