### PR TITLE
fix: Splitting kiiroo_v21 for devices that need initailization

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -1399,15 +1399,10 @@
     "kiiroo-v21": {
       "btle": {
         "names": [
-          "Rey",
-          "We-Vibe Rocketman",
-          "Onyx2.1",
-          "Onyx+",
           "Titan1.1",
           "Cliona",
           "Pearl2.1",
-          "OhMiBod 4.0",
-          "KEON"
+          "OhMiBod 4.0"
         ],
         "services": {
           "00001900-0000-1000-8000-00805f9b34fb": {
@@ -1498,7 +1493,33 @@
             },
             "FleshlightLaunchFW12Cmd": {}
           }
+        }
+      ]
+    },
+    "kiiroo-v21-initialized": {
+      "btle": {
+        "names": [
+          "Rey",
+          "We-Vibe Rocketman",
+          "Onyx2.1",
+          "Onyx+",
+          "KEON"
+        ],
+        "services": {
+          "00001900-0000-1000-8000-00805f9b34fb": {
+            "whitelist": "00001901-0000-1000-8000-00805f9b34fb",
+            "tx": "00001902-0000-1000-8000-00805f9b34fb",
+            "rx": "00001903-0000-1000-8000-00805f9b34fb"
+          }
+        }
+      },
+      "defaults": {
+        "name": {
+          "en-us": "Kiiroo V2.1 Initialized Device"
         },
+        "messages": {}
+      },
+      "configurations": [
         {
           "identifier": [
             "Onyx2.1"

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -1010,15 +1010,10 @@ protocols:
   kiiroo-v21:
     btle:
       names:
-        - Rey # Branded Realm
-        - We-Vibe Rocketman # Rey alias
-        - Onyx2.1
-        - Onyx+
         - Titan1.1
         - Cliona
         - Pearl2.1
         - OhMiBod 4.0
-        - KEON
       services:
         00001900-0000-1000-8000-00805f9b34fb:
           # Used to clear the whitelist
@@ -1074,6 +1069,25 @@ protocols:
             StepCount:
               - 99
           FleshlightLaunchFW12Cmd: {}
+  kiiroo-v21-initialized:
+    btle:
+      names:
+        - Rey # Branded Realm
+        - We-Vibe Rocketman # Rey alias
+        - Onyx2.1
+        - Onyx+
+        - KEON
+      services:
+        00001900-0000-1000-8000-00805f9b34fb:
+          # Used to clear the whitelist
+          whitelist: 00001901-0000-1000-8000-00805f9b34fb
+          tx: 00001902-0000-1000-8000-00805f9b34fb
+          rx: 00001903-0000-1000-8000-00805f9b34fb
+    defaults:
+      name:
+        en-us: Kiiroo V2.1 Initialized Device
+      messages: { }
+    configurations:
       - identifier:
           - Onyx2.1
         name:
@@ -1083,7 +1097,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 99
-          FleshlightLaunchFW12Cmd: {}
+          FleshlightLaunchFW12Cmd: { }
       - identifier:
           - Onyx+
         name:
@@ -1093,7 +1107,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 99
-          FleshlightLaunchFW12Cmd: {}
+          FleshlightLaunchFW12Cmd: { }
       - identifier:
           - KEON
         name:
@@ -1103,7 +1117,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 99
-          FleshlightLaunchFW12Cmd: {}
+          FleshlightLaunchFW12Cmd: { }
       - identifier:
           - Rey
           - We-Vibe Rocketman
@@ -1114,7 +1128,7 @@ protocols:
             FeatureCount: 1
             StepCount:
               - 99
-          FleshlightLaunchFW12Cmd: {}
+          FleshlightLaunchFW12Cmd: { }
   vorze-cyclone-x:
     hid:
       - vendor-id: 0x0483

--- a/buttplug/src/device/protocol/mod.rs
+++ b/buttplug/src/device/protocol/mod.rs
@@ -3,6 +3,7 @@ mod fleshlight_launch_helper;
 mod generic_command_manager;
 mod kiiroo_v2;
 mod kiiroo_v21;
+mod kiiroo_v21_initialized;
 mod kiiroo_v2_vibrator;
 mod lelof1s;
 mod libo_elle;
@@ -63,6 +64,7 @@ pub enum ProtocolTypes {
   KiirooV2,
   KiirooV2Vibrator,
   KiirooV21,
+  KiirooV21Initialized,
   LeloF1s,
   LiboElle,
   LiboShark,
@@ -100,6 +102,7 @@ impl TryFrom<&str> for ProtocolTypes {
       "kiiroo-v2" => Ok(ProtocolTypes::KiirooV2),
       "kiiroo-v2-vibrator" => Ok(ProtocolTypes::KiirooV2Vibrator),
       "kiiroo-v21" => Ok(ProtocolTypes::KiirooV21),
+      "kiiroo-v21-initialized" => Ok(ProtocolTypes::KiirooV21Initialized),
       "lelo-f1s" => Ok(ProtocolTypes::LeloF1s),
       "libo-elle" => Ok(ProtocolTypes::LiboElle),
       "libo-shark" => Ok(ProtocolTypes::LiboShark),
@@ -144,8 +147,11 @@ pub fn try_create_protocol(
     ProtocolTypes::KiirooV2 => kiiroo_v2::KiirooV2::try_create(device, config),
     ProtocolTypes::KiirooV2Vibrator => {
       kiiroo_v2_vibrator::KiirooV2Vibrator::try_create(device, config)
-    }
+    },
     ProtocolTypes::KiirooV21 => kiiroo_v21::KiirooV21::try_create(device, config),
+    ProtocolTypes::KiirooV21Initialized => {
+      kiiroo_v21_initialized::KiirooV21Initialized::try_create(device, config)
+    },
     ProtocolTypes::LeloF1s => lelof1s::LeloF1s::try_create(device, config),
     ProtocolTypes::LiboElle => libo_elle::LiboElle::try_create(device, config),
     ProtocolTypes::LiboShark => libo_shark::LiboShark::try_create(device, config),


### PR DESCRIPTION
We know that the linear devices will accept the initialization without
any obious side-effects, whether needed or not.

The vibes on the otherhand will at best start up at 100% speed
or refuse all commands at worse.

I've left the vibration and linear logic in both protocols, so if
we've got a device in the wrong category, it's just a config change
to fix in the future.

Fixes #281