### PR TITLE
fix: Writer not closing after connector holding websocket is dropped

### DIFF
--- a/buttplug/src/connector/transport/websocket/websocket_client.rs
+++ b/buttplug/src/connector/transport/websocket/websocket_client.rs
@@ -120,6 +120,7 @@ impl ButtplugConnectorTransport for ButtplugWebsocketClientTransport {
                       writer.send(out_msg).await.expect("This should never fail?");
                     } else {
                       info!("Connector holding websocket dropped, returning");
+                      writer.close().await.unwrap_or_else(|err| error!("{}", err));
                       return;
                     }
                   },


### PR DESCRIPTION
This fixes an issue with intiface where on some client disconnects the websocket would get stuck open and would require server restart to allow further connections.