### PR TITLE
feat: Support Svakom Neo Vibes

### DIFF
--- a/buttplug/buttplug-device-config/buttplug-device-config.json
+++ b/buttplug/buttplug-device-config/buttplug-device-config.json
@@ -2055,7 +2055,12 @@
     "svakom": {
       "btle": {
         "names": [
-          "Aogu SCB"
+          "Aogu SUV",
+          "Aogu SCB",
+          "Ella NEO",
+          "Emma NEO",
+          "Phoenix NEO",
+          "Vick NEO"
         ],
         "services": {
           "0000ffe0-0000-1000-8000-00805f9b34fb": {
@@ -2066,7 +2071,7 @@
       },
       "defaults": {
         "name": {
-          "en-us": "Svakom Ella"
+          "en-us": "Svakom Device"
         },
         "messages": {
           "VibrateCmd": {
@@ -2076,7 +2081,41 @@
             ]
           }
         }
-      }
+      },
+      "configurations": [
+        {
+          "identifier": [
+            "Aogu SCB"
+          ],
+          "name": {
+            "en-us": "Svakom Ella"
+          }
+        },
+        {
+          "identifier": [
+            "Ella NEO"
+          ],
+          "name": {
+            "en-us": "Svakom Ella Neo"
+          }
+        },
+        {
+          "identifier": [
+            "Phoenix NEO"
+          ],
+          "name": {
+            "en-us": "Svakom Phoenix Neo"
+          }
+        },
+        {
+          "identifier": [
+            "Vick NEO"
+          ],
+          "name": {
+            "en-us": "Svakom Vick Neo"
+          }
+        }
+      ]
     },
     "realov": {
       "btle": {

--- a/buttplug/buttplug-device-config/buttplug-device-config.yml
+++ b/buttplug/buttplug-device-config/buttplug-device-config.yml
@@ -1408,19 +1408,41 @@ protocols:
   svakom:
     btle:
       names:
+        - Aogu SUV # Unknown
         - Aogu SCB # Ella
+        - Ella NEO
+        - Emma NEO
+        - Phoenix NEO
+        - Vick NEO
       services:
         0000ffe0-0000-1000-8000-00805f9b34fb:
           tx: 0000ffe1-0000-1000-8000-00805f9b34fb
           rx: 0000ffe2-0000-1000-8000-00805f9b34fb
     defaults:
       name:
-        en-us: Svakom Ella
+        en-us: Svakom Device
       messages:
         VibrateCmd:
           FeatureCount: 1
           StepCount:
            - 19
+    configurations:
+      - identifier:
+          - Aogu SCB
+        name:
+          en-us: Svakom Ella
+      - identifier:
+          - Ella NEO
+        name:
+          en-us: Svakom Ella Neo
+      - identifier:
+          - Phoenix NEO
+        name:
+          en-us: Svakom Phoenix Neo
+      - identifier:
+          - Vick NEO
+        name:
+          en-us: Svakom Vick Neo
   realov:
     btle:
       names:


### PR DESCRIPTION
This reuses the prior Svakom protocol, mapping in the
new BLE names (from data privide in #325).

Tested with original Ella and Vick Neo.